### PR TITLE
feat: add group leave and admin transfer

### DIFF
--- a/receipt-app/src/main/java/com/group/receiptapp/domain/group/Group.java
+++ b/receipt-app/src/main/java/com/group/receiptapp/domain/group/Group.java
@@ -22,7 +22,7 @@ public class Group {
     @Column(name = "group_name", nullable = false, unique = true)
     private String name; // 그룹 이름
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "group")
     private List<Member> members = new ArrayList<>(); // 그룹에 속한 사용자들
 
     @Column(name = "prevent_duplicate_receipt", nullable = false)

--- a/receipt-app/src/main/java/com/group/receiptapp/repository/receipt/ReceiptRepository.java
+++ b/receipt-app/src/main/java/com/group/receiptapp/repository/receipt/ReceiptRepository.java
@@ -23,6 +23,7 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
             "JOIN r.category c " +
             "JOIN r.member m " +
             "WHERE m.group.id = :groupId " +
+            "AND m.isActive = true " +
             "AND YEAR(r.date) = :year " +
             "AND MONTH(r.date) = :month " +
             "AND r.isDeleted = false " +
@@ -36,6 +37,7 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
             "FROM Receipt r " +
             "JOIN r.member m " +
             "WHERE m.group.id = :groupId " +
+            "AND m.isActive = true " +
             "AND YEAR(r.date) = :year " +
             "AND MONTH(r.date) = :month " +
             "AND r.isDeleted = false " +
@@ -46,7 +48,9 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
 
     // 그룹별 가장 많이 사용한 점포 조회 (Top 3)
     @Query("SELECT r.storeName, COUNT(r.id), SUM(r.amount) FROM Receipt r " +
-            "WHERE r.member.group.id = :groupId AND YEAR(r.date) = :year AND MONTH(r.date) = :month " +
+            "JOIN r.member m " +
+            "WHERE m.group.id = :groupId AND m.isActive = true " +
+            "AND YEAR(r.date) = :year AND MONTH(r.date) = :month " +
             "AND r.isDeleted = false " +
             "GROUP BY r.storeName " +
             "ORDER BY COUNT(r.id) DESC, SUM(r.amount) DESC")
@@ -57,6 +61,7 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
     // 멤버별 총 지출과 카테고리별 지출 조회
     @Query("SELECT r.category.name, SUM(r.amount) FROM Receipt r " +
             "WHERE r.member.id = :memberId " +
+            "AND r.member.isActive = true " + // 추가 필요
             "AND YEAR(r.date) = :year " +
             "AND MONTH(r.date) = :month " +
             "AND r.isDeleted = false " +
@@ -81,18 +86,20 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
     // 특정 그룹의 연도/월별 영수증 조회
     @Query("SELECT r.id, r.storeName, r.storeAddress, r.memo, r.date, r.amount, " +
             "r.member.name, r.category.name FROM Receipt r " +
-            "WHERE r.member.group.id = :groupId " +
+            "JOIN r.member m " +
+            "WHERE m.group.id = :groupId " +
+            "AND m.isActive = true " +
             "AND YEAR(r.date) = :year " +
             "AND MONTH(r.date) = :month " +
             "AND r.isDeleted = false " +
             "ORDER BY r.date DESC")
-    List<Object[]> getReceiptsByGroupAndDate(
-            @Param("groupId") Long groupId,
-            @Param("year") int year,
-            @Param("month") int month);
+    List<Object[]> getReceiptsByGroupAndDate(@Param("groupId") Long groupId,
+                                             @Param("year") int year,
+                                             @Param("month") int month);
 
     @Query("SELECT r FROM Receipt r " +
             "WHERE r.member.id = :memberId " +
+            "AND r.member.isActive = true " + // 추가 권장
             "AND FUNCTION('YEAR', r.date) = :year " +
             "AND FUNCTION('MONTH', r.date) = :month " +
             "AND r.isDeleted = false")

--- a/receipt-app/src/main/java/com/group/receiptapp/service/member/MemberService.java
+++ b/receipt-app/src/main/java/com/group/receiptapp/service/member/MemberService.java
@@ -7,14 +7,12 @@ import com.group.receiptapp.repository.member.MemberRepository;
 import com.group.receiptapp.repository.member.RefreshTokenRepository;
 import com.group.receiptapp.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @Service
 @Transactional(readOnly = false)
@@ -78,11 +76,42 @@ public class MemberService {
 
     // 회원 탈퇴
     public void deleteAccount(String token) {
-        String email = jwtUtil.extractUsername(token); // JwtUtil 사용
+        String email = jwtUtil.extractUsername(token);
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
 
-        member.deactivate(); // 회원 탈퇴 처리 (isActive = false)
+        if (!member.isActive()) {
+            throw new IllegalStateException("이미 탈퇴된 회원입니다.");
+        }
+
+        Group group = member.getGroup();
+
+        if (member.isAdmin()) {
+            if (group != null) {
+                // 그룹 내 현재 관리자 외 다른 멤버가 있는지 확인
+                List<Member> otherActiveMembers = group.getMembers().stream()
+                        .filter(m -> !m.getId().equals(member.getId()) && m.isActive())
+                        .toList();
+
+                if (otherActiveMembers.isEmpty()) {
+                    member.setGroup(null);         // 연결 해제
+                    member.deactivate();           // isActive = false
+                    memberRepository.save(member); // 변경 사항 저장
+
+                    groupRepository.delete(group); // 그룹 삭제
+                    refreshTokenRepository.deleteByMemberId(member.getId());
+                    return;
+                } else {
+                    // 다른 멤버에게 권한 위임을 해야 함
+                    throw new IllegalStateException("탈퇴하려면 먼저 다른 멤버에게 관리자 권한을 위임해야 합니다.");
+                }
+            }
+        }
+
+        // 일반 멤버 탈퇴 또는 관리자 권한 위임 후 탈퇴
+        member.deactivate();
+        member.setGroup(null);
+        memberRepository.save(member);
         refreshTokenRepository.deleteByMemberId(member.getId());
     }
 
@@ -97,4 +126,38 @@ public class MemberService {
         member.setPassword(encoded);
         memberRepository.save(member);
     }
+
+    @Transactional
+    public String leaveGroup(Member member) {
+        Group group = member.getGroup();
+        if (group == null) {
+            throw new IllegalStateException("소속된 그룹이 없습니다.");
+        }
+
+        // 그룹 연결 해제
+        member.setGroup(null);
+        memberRepository.save(member);
+
+        // 자신을 제외한 활성 멤버가 있는지 확인
+        List<Member> remaining = group.getMembers().stream()
+                .filter(Member::isActive)
+                .filter(m -> !m.getId().equals(member.getId()))
+                .toList();
+
+        if (remaining.isEmpty()) {
+            // 모든 멤버의 group 연결 끊기
+            for (Member m : group.getMembers()) {
+                m.setGroup(null); // 관계 끊기
+                memberRepository.save(m); // 변경 사항 저장
+            }
+
+            // group 삭제
+            groupRepository.delete(group);
+
+            return "그룹 마지막 멤버 탈퇴, 그룹 삭제 완료";
+        }
+
+        return "그룹에서 성공적으로 탈퇴하였습니다.";
+    }
+
 }


### PR DESCRIPTION
1. 회원탈퇴 기능 리팩토링
(1) 그룹 1명인 관리자가 회원 탈퇴하기
 - 해당 멤버는 `isActive = false`, `group = null`
 - 그룹은 DB에서 삭제
(2) 일반 멤버 탈퇴
- `isActive = false`, `group = null`

2. 그룹 통계에서 탈퇴한 멤버 제외하도록 수정

3. 관리자 권한 위임 기능 api 추가
- 같은 그룹 내 다른 활성 멤버에게만 위임 가능
- 본인에게 위임 불가
- 위임 완료 후 그룹 탈퇴 가능

4. 그룹 탈퇴 기능 api 추가
- 관리자는 탈퇴 제한 response
- 마지막 멤버가 아닌 일반 멤버의 그룹 탈퇴시: 
- 마지막 멤버인 일반 멤버의 그룹 탈퇴: 그룹에서 탈퇴(groupId = null), 그룹 db에서 삭제